### PR TITLE
Fix a but on adding a product without attribute to cart

### DIFF
--- a/src/pages/Details.js
+++ b/src/pages/Details.js
@@ -409,7 +409,7 @@ class Details extends PureComponent {
                     quantity: 1,
                   };
                   this.addProductToCart(cartItem);
-                  this.setState({ isInCart: true });
+                  this.setState({ noAttributeProduct: cartItem, isInCart: true });
                   this.changeButtonContent('REMOVE ITEM');
                   this.showStatus(
                     'Product successfully added to cart!',


### PR DESCRIPTION
In this pull request, I fixed the bug of having a blank screen when you add a product without categories to the cart from the PDP page.